### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
         "grunt-run": "^0.8.0",
         "grunt-sass": "^2.0.0",
         "grunt-svgstore": "^1.0.0",
-        "npm": "^6.9.0",
         "update-notifier": "^2.3.0"
     }
 }


### PR DESCRIPTION

Hello tayloragriffin!

It seems like you have npm as one of your (dev-) dependency in starter-theme1.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
